### PR TITLE
feat: add docker compose for running images

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,6 @@
+//SPDX-FileCopyrightText: Alliander N. V.
+//
+//SPDX-License-Identifier: Apache-2.0
 {
     "name": "Franka",
     // Update the 'dockerComposeFile' list if you have more compose files or use different names.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+    "name": "Franka",
+    // Update the 'dockerComposeFile' list if you have more compose files or use different names.
+    "dockerComposeFile": "docker-compose.yml",
+    // The 'service' property is the name of the service for the container that VS Code should
+    // use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+    "service": "franka",
+    // The 'workspaceFolder' property is the path VS Code should open by default when
+    // connected. Corresponds to a volume mount in .devcontainer/docker-compose.yml
+    "workspaceFolder": "/home/${localEnv:USER}/docker_ws/src",
+    // Set *default* container specific settings.json values on container create.
+    "settings": {},
+    // Add the IDs of extensions you want installed when the container is created.
+    "extensions": [],
+    // Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+    // "shutdownAction": "none",
+    // Uncomment the next line to use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "uname -a",
+    // Comment out to connect as root instead. To add a non-root user, see: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "${localEnv:USER}"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     environment:
       - "DISPLAY"
       - "RCUTILS_COLORIZED_OUTPUT=1"
+    tty: true
   mobile_manipulator:
     image: mobile_manipulator
     container_name: mobile_manipulator
@@ -31,6 +32,7 @@ services:
     environment:
       - "DISPLAY"
       - "RCUTILS_COLORIZED_OUTPUT=1"
+    tty: true
   panther:
     image: panther
     container_name: panther
@@ -45,6 +47,7 @@ services:
     environment:
       - "DISPLAY"
       - "RCUTILS_COLORIZED_OUTPUT=1"
+    tty: true
   ros2:
     image: ros2
     container_name: ros2
@@ -58,3 +61,4 @@ services:
     environment:
       - "DISPLAY"
       - "RCUTILS_COLORIZED_OUTPUT=1"
+    tty: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Alliander N. V.
+# 
+# SPDX-License-Identifier: Apache-2.0
+
+services:
+  franka:
+    image: franka
+    container_name: franka
+    network_mode: host
+    privileged: true
+    mem_limit: 6gb
+    volumes:
+      - "/tmp/.X11-unix:/tmp/.X11-unix"
+      - "${HOME}/.vscode-server:${HOME}/.vscode-server"
+      - "${HOME}/docker_ws:${HOME}/docker_ws"
+      - "/dev:/dev"
+    environment:
+      - "DISPLAY"
+      - "RCUTILS_COLORIZED_OUTPUT=1"
+  mobile_manipulator:
+    image: mobile_manipulator
+    container_name: mobile_manipulator
+    network_mode: host
+    privileged: true
+    mem_limit: 6gb
+    volumes:
+      - "/tmp/.X11-unix:/tmp/.X11-unix"
+      - "${HOME}/.vscode-server:${HOME}/.vscode-server"
+      - "${HOME}/docker_ws:${HOME}/docker_ws"
+      - "/dev/input:/dev/input"
+    environment:
+      - "DISPLAY"
+      - "RCUTILS_COLORIZED_OUTPUT=1"
+  panther:
+    image: panther
+    container_name: panther
+    network_mode: host
+    privileged: true
+    mem_limit: 6gb
+    volumes:
+      - "/tmp/.X11-unix:/tmp/.X11-unix"
+      - "${HOME}/.vscode-server:${HOME}/.vscode-server"
+      - "${HOME}/docker_ws:${HOME}/docker_ws"
+      - "/dev/input:/dev/input"
+    environment:
+      - "DISPLAY"
+      - "RCUTILS_COLORIZED_OUTPUT=1"
+  ros2:
+    image: ros2
+    container_name: ros2
+    network_mode: host
+    privileged: true
+    mem_limit: 6gb
+    volumes:
+      - "/tmp/.X11-unix:/tmp/.X11-unix"
+      - "${HOME}/.vscode-server:${HOME}/.vscode-server"
+      - "${HOME}/docker_ws:${HOME}/docker_ws"
+    environment:
+      - "DISPLAY"
+      - "RCUTILS_COLORIZED_OUTPUT=1"

--- a/run
+++ b/run
@@ -48,7 +48,7 @@ mkdir -p ~/.vscode-server
 #If installed, launch the image:
 if $installed; then
     printf 'Starting %s...\n\n' "$image"
-    docker compose run --rm $image
+    docker compose -f .devcontainer/docker-compose.yml run --rm $image
 
 #If not installed, ask to install:
 else

--- a/run
+++ b/run
@@ -45,28 +45,11 @@ fi
 mkdir -p ~/docker_ws
 mkdir -p ~/.vscode-server
 
-#If installed, launch the image with xhost:
+#If installed, launch the image:
 if $installed; then
     printf 'Starting %s...\n\n' "$image"
+    docker compose run --rm $image
 
-    printf "Get acces to xhost...\n"
-    xhost +local:docker
-    printf "Done. \n\n"
-
-    docker run -it --privileged --rm \
-        --memory=6g \
-        --env DISPLAY \
-        --env RCUTILS_COLORIZED_OUTPUT=1 \
-        --network=host \
-        -v /tmp/.X11-unix:/tmp/.X11-unix \
-        -v /dev/input:/dev/input \
-        -v ~/.vscode-server:/home/"$USER"/.vscode-server \
-        -v ~/docker_ws:/home/"$USER"/docker_ws \
-        "$image"
-
-    printf "\nStop accces to xhost...\n"
-    xhost -local:docker
-    printf "Done.\n"
 #If not installed, ask to install:
 else
     build=$(whiptail --title "Install?" \


### PR DESCRIPTION
Adding docker compose helps standardising running images. It also allows for easy integration with other tooling in the future (e.g. devcontainers).

Still, backward compatibility is ensured by maintaining run-script functionality.