### PR TITLE
feat: ensure building moveit succeeds on all machines (hopefully)

### DIFF
--- a/dockerfiles/general/dep_dev.Dockerfile
+++ b/dockerfiles/general/dep_dev.Dockerfile
@@ -9,7 +9,7 @@
 # rcdt_detection
 RUN python3 -m pip install pyrealsense2
 RUN python3 -m pip install ultralytics
-RUN python3 -m pip install "numpy<2.0"
+RUN python3 -m pip install "numpy>=1.23.0,<2.0"
 RUN apt install -y ros-humble-realsense2-camera
 RUN apt install -y ros-humble-realsense2-description
 

--- a/dockerfiles/general/moveit.Dockerfile
+++ b/dockerfiles/general/moveit.Dockerfile
@@ -10,5 +10,5 @@ RUN for repo in moveit2/moveit2.repos $(f="moveit2/moveit2_$ROS_DISTRO.repos"; t
 RUN rosdep install -r --from-paths . --ignore-src --rosdistro $ROS_DISTRO -y
 
 WORKDIR /home/$UNAME/moveit_ws/
-RUN . /opt/ros/humble/setup.sh && colcon build --event-handlers desktop_notification- status- --cmake-args -DCMAKE_BUILD_TYPE=Release
+RUN . /opt/ros/humble/setup.sh && colcon build --event-handlers desktop_notification- status- --cmake-args -DCMAKE_BUILD_TYPE=Release --executor sequential
 RUN echo "source /home/$UNAME/moveit_ws/install/setup.bash" >> /home/$UNAME/.bashrc

--- a/dockerfiles/general/moveit.Dockerfile
+++ b/dockerfiles/general/moveit.Dockerfile
@@ -10,5 +10,5 @@ RUN for repo in moveit2/moveit2.repos $(f="moveit2/moveit2_$ROS_DISTRO.repos"; t
 RUN rosdep install -r --from-paths . --ignore-src --rosdistro $ROS_DISTRO -y
 
 WORKDIR /home/$UNAME/moveit_ws/
-RUN . /opt/ros/humble/setup.sh && colcon build --event-handlers desktop_notification- status- --cmake-args -DCMAKE_BUILD_TYPE=Release --executor sequential
+RUN . /opt/ros/humble/setup.sh && colcon build --event-handlers desktop_notification- status- --cmake-args -DCMAKE_BUILD_TYPE=Release ${COLCON_BUILD_SEQUENTIAL:+--executor sequential}
 RUN echo "source /home/$UNAME/moveit_ws/install/setup.bash" >> /home/$UNAME/.bashrc

--- a/dockerfiles/general/pre_install.Dockerfile
+++ b/dockerfiles/general/pre_install.Dockerfile
@@ -7,6 +7,7 @@ FROM osrf/ros:humble-desktop-full
 ARG UNAME
 ARG UID
 ARG GID
+ARG COLCON_BUILD_SEQUENTIAL
 
 #Remove existing user with same UID if exists:
 RUN if getent passwd $UID; then userdel $(id -nu $UID); else :; fi

--- a/run
+++ b/run
@@ -35,15 +35,25 @@ clear
 [[ -z "$image" ]] && exit 1
 
 if [ -z "$(docker images -q $image 2> /dev/null)" ]; then
-    build=$(whiptail --clear \
-        --title "Build?" \
-        --menu "The selected image was not found. Do you want to build the image?" \
+    use_cache=$(whiptail --clear \
+        --title "Build with cache?" \
+        --menu "Image '$image' is not found. Do you want to build it with or without cache?" \
         $MENU_HEIGHT $MENU_WIDTH $CHOICE_HEIGHT \
-        "yes" "" \
-        "yes, without cache" "" \
+        "with cache" "" \
+        "without cache" "" \
         2>&1 >/dev/tty)
     clear
-    [[ -z "$build" ]] && exit 1
+    [[ -z "$use_cache" ]] && exit 1
+
+    colcon_build_sequential=$(whiptail --clear \
+        --title "Build?" \
+        --menu "Image '$image' is not found. Do you want to build it parallel (higher load) or sequential (slower)?" \
+        $MENU_HEIGHT $MENU_WIDTH $CHOICE_HEIGHT \
+        "parallel" "" \
+        "sequential" "" \
+        2>&1 >/dev/tty)
+    clear
+    [[ -z "$colcon_build_sequential" ]] && exit 1
 
     if [ ! "$(docker buildx inspect $DOCKER_BUILDER_NAME 2> /dev/null)" ]; then
         docker buildx create \
@@ -53,13 +63,15 @@ if [ -z "$(docker images -q $image 2> /dev/null)" ]; then
           --driver-opt default-load=true
     fi
 
-    NO_CACHE=$([ "$build" == "yes, without cache" ] && echo "true" || echo "")
+    NO_CACHE=$([ "$use_cache" == "without cache" ] && echo "true" || echo "")
+    COLCON_BUILD_SEQUENTIAL=$([ "$colcon_build_sequential" == "sequential" ] && echo "true" || echo "")
     docker build \
       ${NO_CACHE:+--no-cache} \
       --builder=$DOCKER_BUILDER_NAME \
       --build-arg UNAME="$USER" \
       --build-arg UID="$(id -u)" \
       --build-arg GID="$(id -g)" \
+      --build-arg COLCON_BUILD_SEQUENTIAL="$COLCON_BUILD_SEQUENTIAL" \
       -t "$image" \
       -f "$SCRIPT_DIR_PATH/dockerfiles/$image.Dockerfile" \
       "$SCRIPT_DIR_PATH/dockerfiles"

--- a/run
+++ b/run
@@ -4,86 +4,66 @@
 # 
 # SPDX-License-Identifier: Apache-2.0
 
-#Define script path:
-script_path=$(
-    cd "$(dirname "${BASH_SOURCE[0]}")" || exit
-    pwd -P
-)
+set -e
 
-#Define menu settings:
-height=20
-width=50
-choice_height=10
+SCRIPT_DIR_PATH=$(dirname $(realpath "$0"))
+MENU_HEIGHT=$(($LINES))
+MENU_WIDTH=$(($COLUMNS))
+CHOICE_HEIGHT=$MENU_HEIGHT
+DOCKER_BUILDER_NAME=ram-constrained-builder
 
-#Define image options based on dockerfiles in dockerfiles directory:
+# If required directories do not exist, create them
+mkdir -p ~/docker_ws
+mkdir -p ~/.vscode-server
+
+# Define image options based on dockerfiles in dockerfiles directory
 options=()
-for dockerfile in "$script_path"/dockerfiles/*.Dockerfile; do
+for dockerfile in "$SCRIPT_DIR_PATH"/dockerfiles/*.Dockerfile; do
     name=${dockerfile%.*}
     options+=("$(basename "$name")")
     options+=("")
 done
 
-#Ask user for image option:
+# Ask user for image option
 image=$(whiptail --clear \
     --title "RCDT Docker Launcher" \
     --menu "Which docker image would you like to run?" \
-    $height $width $choice_height \
+    $MENU_HEIGHT $MENU_WIDTH $CHOICE_HEIGHT \
     "${options[@]}" \
     2>&1 >/dev/tty)
 clear
-[[ -z "$image" ]] && { return 1; }
+[[ -z "$image" ]] && exit 1
 
-#Check if the image is already installed:
-lines=$(docker images "$image" | wc -l)
-if [ "$lines" == 2 ]; then
-    installed=true
-else
-    installed=false
-fi
-
-#If no docker_ws directory exists, create it:
-mkdir -p ~/docker_ws
-mkdir -p ~/.vscode-server
-
-#If installed, launch the image:
-if $installed; then
-    printf 'Starting %s...\n\n' "$image"
-    docker compose -f .devcontainer/docker-compose.yml run --rm $image
-
-#If not installed, ask to install:
-else
-    build=$(whiptail --title "Install?" \
-        --menu "The selected image was not found. Do you want to install the image?" \
-        $height $width $choice_height \
+if [ -z "$(docker images -q $image 2> /dev/null)" ]; then
+    build=$(whiptail --clear \
+        --title "Build?" \
+        --menu "The selected image was not found. Do you want to build the image?" \
+        $MENU_HEIGHT $MENU_WIDTH $CHOICE_HEIGHT \
         "yes" "" \
         "yes, without cache" "" \
-        "no" "" \
         2>&1 >/dev/tty)
     clear
-    [[ -z "$build" ]] && { return 1; }
+    [[ -z "$build" ]] && exit 1
 
-    if [ "$build" == "yes" ]; then
-        # Build with cache:
-        docker build \
-            --memory=6g \
-            --build-arg UNAME="$USER" \
-            --build-arg UID="$(id -u)" \
-            --build-arg GID="$(id -g)" \
-            -t "$image" \
-            -f "$script_path/dockerfiles/$image.Dockerfile" \
-            "$script_path/dockerfiles"
-    elif [ "$build" == "yes, without cache" ]; then
-        # Build without cache:
-        docker build \
-            --no-cache \
-            --memory=6g \
-            --build-arg UNAME="$USER" \
-            --build-arg UID="$(id -u)" \
-            --build-arg GID="$(id -g)" \
-            -t "$image" \
-            -f "$script_path/dockerfiles/$image.Dockerfile" \
-            "$script_path/dockerfiles"
-    else
-        return 1
+    if [ ! "$(docker buildx inspect $DOCKER_BUILDER_NAME 2> /dev/null)" ]; then
+        docker buildx create \
+          --name $DOCKER_BUILDER_NAME \
+          --driver=docker-container \
+          --driver-opt memory=14g \
+          --driver-opt default-load=true
     fi
+
+    NO_CACHE=$([ "$build" == "yes, without cache" ] && echo "true" || echo "")
+    docker build \
+      ${NO_CACHE:+--no-cache} \
+      --builder=$DOCKER_BUILDER_NAME \
+      --build-arg UNAME="$USER" \
+      --build-arg UID="$(id -u)" \
+      --build-arg GID="$(id -g)" \
+      -t "$image" \
+      -f "$SCRIPT_DIR_PATH/dockerfiles/$image.Dockerfile" \
+      "$SCRIPT_DIR_PATH/dockerfiles"
 fi
+
+echo Running $image ...
+docker compose -f $SCRIPT_DIR_PATH/.devcontainer/docker-compose.yml run --rm $image

--- a/run
+++ b/run
@@ -4,13 +4,14 @@
 # 
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
-
-SCRIPT_DIR_PATH=$(dirname $(realpath "$0"))
-MENU_HEIGHT=$(($LINES))
-MENU_WIDTH=$(($COLUMNS))
-CHOICE_HEIGHT=$MENU_HEIGHT
+MENU_HEIGHT=$(($LINES - 3))
+MENU_WIDTH=$(($COLUMNS - 80))
 DOCKER_BUILDER_NAME=ram-constrained-builder
+
+SCRIPT_DIR_PATH=$(
+    cd "$(dirname "${BASH_SOURCE[0]}")" || exit
+    pwd -P
+)
 
 # If required directories do not exist, create them
 mkdir -p ~/docker_ws
@@ -23,16 +24,17 @@ for dockerfile in "$SCRIPT_DIR_PATH"/dockerfiles/*.Dockerfile; do
     options+=("$(basename "$name")")
     options+=("")
 done
+choice_height="${#options[@]}"
 
 # Ask user for image option
 image=$(whiptail --clear \
     --title "RCDT Docker Launcher" \
     --menu "Which docker image would you like to run?" \
-    $MENU_HEIGHT $MENU_WIDTH $CHOICE_HEIGHT \
+    $MENU_HEIGHT $MENU_WIDTH $choice_height \
     "${options[@]}" \
     2>&1 >/dev/tty)
 clear
-[[ -z "$image" ]] && exit 1
+[[ -z "$image" ]] && return 1
 
 if [ -z "$(docker images -q $image 2> /dev/null)" ]; then
     use_cache=$(whiptail --clear \
@@ -43,7 +45,7 @@ if [ -z "$(docker images -q $image 2> /dev/null)" ]; then
         "without cache" "" \
         2>&1 >/dev/tty)
     clear
-    [[ -z "$use_cache" ]] && exit 1
+    [[ -z "$use_cache" ]] && return 1
 
     colcon_build_sequential=$(whiptail --clear \
         --title "Build?" \
@@ -53,9 +55,11 @@ if [ -z "$(docker images -q $image 2> /dev/null)" ]; then
         "sequential" "" \
         2>&1 >/dev/tty)
     clear
-    [[ -z "$colcon_build_sequential" ]] && exit 1
+    [[ -z "$colcon_build_sequential" ]] && return 1
 
-    if [ ! "$(docker buildx inspect $DOCKER_BUILDER_NAME 2> /dev/null)" ]; then
+    ram_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+    RAM_CONSTRAINED=$([ $RAM_KB -lt 16000000 ] && echo "true" || echo "")
+    if [ ! "$(docker buildx inspect $DOCKER_BUILDER_NAME 2> /dev/null)" ] && [ $RAM_CONSTRAINED = "true" ]; then
         docker buildx create \
           --name $DOCKER_BUILDER_NAME \
           --driver=docker-container \
@@ -67,7 +71,7 @@ if [ -z "$(docker images -q $image 2> /dev/null)" ]; then
     COLCON_BUILD_SEQUENTIAL=$([ "$colcon_build_sequential" == "sequential" ] && echo "true" || echo "")
     docker build \
       ${NO_CACHE:+--no-cache} \
-      --builder=$DOCKER_BUILDER_NAME \
+      ${RAM_CONSTRAINED:+--builder=$DOCKER_BUILDER_NAME} \
       --build-arg UNAME="$USER" \
       --build-arg UID="$(id -u)" \
       --build-arg GID="$(id -g)" \

--- a/run
+++ b/run
@@ -24,13 +24,12 @@ for dockerfile in "$SCRIPT_DIR_PATH"/dockerfiles/*.Dockerfile; do
     options+=("$(basename "$name")")
     options+=("")
 done
-choice_height="${#options[@]}"
 
 # Ask user for image option
 image=$(whiptail --clear \
     --title "RCDT Docker Launcher" \
     --menu "Which docker image would you like to run?" \
-    $MENU_HEIGHT $MENU_WIDTH $choice_height \
+    $MENU_HEIGHT $MENU_WIDTH $MENU_WIDTH \
     "${options[@]}" \
     2>&1 >/dev/tty)
 clear
@@ -40,7 +39,7 @@ if [ -z "$(docker images -q $image 2> /dev/null)" ]; then
     use_cache=$(whiptail --clear \
         --title "Build with cache?" \
         --menu "Image '$image' is not found. Do you want to build it with or without cache?" \
-        $MENU_HEIGHT $MENU_WIDTH $CHOICE_HEIGHT \
+        $MENU_HEIGHT $MENU_WIDTH $MENU_WIDTH \
         "with cache" "" \
         "without cache" "" \
         2>&1 >/dev/tty)
@@ -50,7 +49,7 @@ if [ -z "$(docker images -q $image 2> /dev/null)" ]; then
     colcon_build_sequential=$(whiptail --clear \
         --title "Build?" \
         --menu "Image '$image' is not found. Do you want to build it parallel (higher load) or sequential (slower)?" \
-        $MENU_HEIGHT $MENU_WIDTH $CHOICE_HEIGHT \
+        $MENU_HEIGHT $MENU_WIDTH $MENU_WIDTH \
         "parallel" "" \
         "sequential" "" \
         2>&1 >/dev/tty)
@@ -58,7 +57,7 @@ if [ -z "$(docker images -q $image 2> /dev/null)" ]; then
     [[ -z "$colcon_build_sequential" ]] && return 1
 
     ram_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
-    RAM_CONSTRAINED=$([ $RAM_KB -lt 16000000 ] && echo "true" || echo "")
+    RAM_CONSTRAINED=$([ $ram_kb -lt 16000000 ] && echo "true" || echo "")
     if [ ! "$(docker buildx inspect $DOCKER_BUILDER_NAME 2> /dev/null)" ] && [ $RAM_CONSTRAINED = "true" ]; then
         docker buildx create \
           --name $DOCKER_BUILDER_NAME \


### PR DESCRIPTION
Nu kan er (als het goed is) met elke machine met genoeg (>14gb) RAM het franka image gebouwd worden.
Het run-script heb ik ook wat aangepast om hem leesbaarder en simpeler te maken. Ook wordt de image nu direct gedraaid als hij nog gebouwd moet worden. Hiervoor moest het run-script opnieuw gedraaid worden.

Ten slotte heeft de numpy-dependency een minimale versie gekregen, de requirement is nu expliciet ipv impliciet.